### PR TITLE
LPS-75438 Line breaks in web content article description are ignored in Asset Publisher

### DIFF
--- a/journal-web/src/main/resources/META-INF/resources/asset/abstract.jsp
+++ b/journal-web/src/main/resources/META-INF/resources/asset/abstract.jsp
@@ -46,4 +46,4 @@ if (Validator.isNull(summary)) {
 }
 %>
 
-<%= StringUtil.shorten(HtmlUtil.stripHtml(summary), abstractLength) %>
+<%= HtmlUtil.replaceNewLine(StringUtil.shorten(HtmlUtil.stripHtml(summary), abstractLength)) %>


### PR DESCRIPTION
fix: Replace newlines in web content article description