### PR TITLE
LPS-75489 Line breaks in web content folder description are ignored when click folder's link in Asset Publisher

### DIFF
--- a/journal-web/src/main/resources/META-INF/resources/asset/folder_full_content.jsp
+++ b/journal-web/src/main/resources/META-INF/resources/asset/folder_full_content.jsp
@@ -31,7 +31,7 @@ JournalFolder folder = journalDisplayContext.getFolder();
 		<aui:col cssClass="lfr-asset-column lfr-asset-column-details" width="<%= 100 %>">
 			<c:if test="<%= Validator.isNotNull(folder.getDescription()) %>">
 				<div class="lfr-asset-description">
-					<%= HtmlUtil.escape(folder.getDescription()) %>
+					<%= HtmlUtil.replaceNewLine(HtmlUtil.escape(folder.getDescription())) %>
 				</div>
 			</c:if>
 


### PR DESCRIPTION
fix: Replace newlines.